### PR TITLE
Make primary key autoincrement optional

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "prettier.semi": false,
+    "prettier.singleQuote": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "prettier.semi": false,
-    "prettier.singleQuote": true
-}

--- a/src/query_builder/schema.js
+++ b/src/query_builder/schema.js
@@ -1,6 +1,6 @@
 export const customTypes = { JSON: 'TEXT' }
 
-/* Creates a string with the columns to create a table like: 
+/* Creates a string with the columns to create a table like:
  *  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, name TEXT, age INTEGER
  */
 export function _createTableColumns(columnMapping) {
@@ -9,7 +9,8 @@ export function _createTableColumns(columnMapping) {
       const type = i[1].type
       const parts = [i[0], customTypes[type] || type]
       if (i[1].primary_key) {
-        parts.push('NOT NULL PRIMARY KEY AUTOINCREMENT')
+        parts.push('NOT NULL PRIMARY KEY')
+        if (i[1].autoincrement) parts.push('AUTOINCREMENT')
       } else {
         if (i[1].unique) parts.push('UNIQUE')
         if (i[1].not_null) parts.push('NOT NULL')


### PR DESCRIPTION
Currently the field declared as primary key in models is set to autoincrement by default, this means that if we want a TEXT primary key the code will just throw an error because a TEXT field can't be autoincremented.

I added an optional parameter `autoincrement` to fields declaration