### PR TITLE
Ignore empty and undefined fields

### DIFF
--- a/__tests__/query_builder/read.test.ts
+++ b/__tests__/query_builder/read.test.ts
@@ -51,13 +51,13 @@ describe('query', () => {
       expect(queryWhere(options)).toBe(expected)
     })
 
-    it('queryWhere with empty or undefined params', () => {
+    it('queryWhere with undefined params', () => {
       const options = {
         name: { contains: 'Daniel' },
         status: { equals: '' },
         created_at: { gt: undefined }
       }
-      const expected = 'WHERE name LIKE ?'
+      const expected = 'WHERE name LIKE ? AND status = ?'
       expect(queryWhere(options)).toBe(expected)
     })
   })

--- a/__tests__/query_builder/read.test.ts
+++ b/__tests__/query_builder/read.test.ts
@@ -18,14 +18,14 @@ it('find statement', () => {
 describe('query', () => {
   describe('auxiliar methods', () => {
     it.each([
-      ['created_at', { equals: '' }, 'created_at = ?'],
-      ['created_at', { notEquals: '' }, 'created_at <> ?'],
-      ['created_at', { lt: '' }, 'created_at < ?'],
-      ['created_at', { lte: '' }, 'created_at <= ?'],
-      ['created_at', { gt: '' }, 'created_at > ?'],
-      ['created_at', { gte: '' }, 'created_at >= ?'],
-      ['created_at', { lt: '', gt: '' }, 'created_at < ? AND created_at > ?'],
-      ['name', { contains: '' }, 'name LIKE ?']
+      ['created_at', { equals: Date.now() }, 'created_at = ?'],
+      ['created_at', { notEquals:Date.now() }, 'created_at <> ?'],
+      ['created_at', { lt:Date.now() }, 'created_at < ?'],
+      ['created_at', { lte:Date.now() }, 'created_at <= ?'],
+      ['created_at', { gt:Date.now() }, 'created_at > ?'],
+      ['created_at', { gte:Date.now() }, 'created_at >= ?'],
+      ['created_at', { lt:Date.now(), gt:Date.now() }, 'created_at < ? AND created_at > ?'],
+      ['name', { contains:Date.now() }, 'name LIKE ?']
     ])('propertyOperation %s %s %s', (property, options, expected) => {
       expect(propertyOperation(property, options)).toBe(expected)
     })
@@ -48,6 +48,16 @@ describe('query', () => {
         created_at: { gt: new Date() }
       }
       const expected = 'WHERE name LIKE ? AND status = ? AND created_at > ?'
+      expect(queryWhere(options)).toBe(expected)
+    })
+
+    it('queryWhere with empty or undefined params', () => {
+      const options = {
+        name: { contains: 'Daniel' },
+        status: { equals: '' },
+        created_at: { gt: undefined }
+      }
+      const expected = 'WHERE name LIKE ?'
       expect(queryWhere(options)).toBe(expected)
     })
   })

--- a/src/query_builder/read.ts
+++ b/src/query_builder/read.ts
@@ -91,7 +91,7 @@ export function queryWhere<T = any>(options: IQueryWhere<T>) {
     
     // Ignore empty or undefined fields
     conditions = Object.keys(conditions).reduce((acc, key) => {
-      if (conditions[key]) acc[key] = conditions[key]
+      if (conditions[key] !== undefined) acc[key] = conditions[key]
       return acc
     }, {})
     

--- a/src/query_builder/read.ts
+++ b/src/query_builder/read.ts
@@ -88,8 +88,15 @@ export function propertyOperation<T extends {}>(property: keyof T, options: Part
 // Build where query
 export function queryWhere<T = any>(options: IQueryWhere<T>) {
   const list = Object.entries(options).map(([property, conditions]) => {
+    
+    // Ignore empty or undefined fields
+    conditions = Object.keys(conditions).reduce((acc, key) => {
+      if (conditions[key]) acc[key] = conditions[key]
+      return acc
+    }, {})
+    
     return `${propertyOperation(property, conditions)}`
-  })
+  }).filter((item) => Object.values(item).length > 0)
   return list.length > 0 ? `WHERE ${list.join(' AND ')}` : ''
 }
 


### PR DESCRIPTION
Adicionado isso pois em casos de telas que filtram precisamos ficar limpando o where quando apaga o conteúdo do input ou quando ele esta undefined